### PR TITLE
fix: yargs v18 API 修正と deploy key による master 直接 push 対応

### DIFF
--- a/.github/generate-readme/src/main.ts
+++ b/.github/generate-readme/src/main.ts
@@ -1,6 +1,7 @@
 import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
-import * as yargs from 'yargs'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 
 function getMavenMetadataFiles(dirpath: string) {
   const files: string[] = []
@@ -110,7 +111,7 @@ ${versions}
 }
 
 function main() {
-  const argv = yargs
+  const argv = yargs(hideBin(process.argv))
     .option('target', {
       description: 'Target path',
       type: 'string',

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -53,6 +53,7 @@ jobs:
       run: pnpm start --target ../../ --output ../../README.md
 
     - name: Setup SSH for push
+      if: github.ref == 'refs/heads/master'
       env:
         PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
       run: |
@@ -90,6 +91,7 @@ jobs:
         git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
 
     - name: Commit & Push
+      if: github.ref == 'refs/heads/master'
       run: |
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -52,12 +52,46 @@ jobs:
       working-directory: ./.github/generate-readme/
       run: pnpm start --target ../../ --output ../../README.md
 
+    - name: Setup SSH for push
+      env:
+        PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+
+        # 秘密鍵を書き込む
+        echo "$PUSH_DEPLOY_KEY" > ~/.ssh/deploy_ed25519
+        chmod 600 ~/.ssh/deploy_ed25519
+
+        # GitHub の公式 SSH ホスト鍵を固定値で書き込む（ssh-keyscan による MITM リスクを回避）
+        cat > ~/.ssh/known_hosts << 'KNOWNHOSTS'
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+        KNOWNHOSTS
+
+        # SSH config を設定
+        cat > ~/.ssh/config << 'SSHCONFIG'
+        Host github.com
+          IdentityFile ~/.ssh/deploy_ed25519
+          StrictHostKeyChecking yes
+          UserKnownHostsFile ~/.ssh/known_hosts
+          BatchMode yes
+        SSHCONFIG
+
+        # SSH 接続テストで Deploy Key 認証を事前確認（exit 1 は GitHub の正常動作）
+        ssh_output=$(ssh -T git@github.com 2>&1 || true)
+        echo "$ssh_output"
+        if [[ "$ssh_output" != *"successfully authenticated"* ]]; then
+          echo "SSH authentication failed"
+          exit 1
+        fi
+
+        # Deploy Key で Ruleset をバイパスするため SSH URL に変更
+        git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+
     - name: Commit & Push
       run: |
-        git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git status | grep modified && git add -A && git commit -v -m "feat: Updated README.md [skip ci]" || true
-        git push origin HEAD:${GITHUB_REF};
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git push origin HEAD:master


### PR DESCRIPTION
## 概要

`generate-readme` ワークフローで発生していた 2 つの問題を修正し、セキュリティ上の問題も合わせて対処しました。

## 変更内容

### 1. yargs v18 API 修正 (`.github/generate-readme/src/main.ts`)

yargs v18 の破壊的変更により、`import * as yargs from 'yargs'` での名前空間インポートでは `.option()` が chainable メソッドとして使えなくなりました。

- **修正前**: `import * as yargs from 'yargs'` → `TypeError: yargs.option is not a function`
- **修正後**: `import yargs from 'yargs'` + `import { hideBin } from 'yargs/helpers'` を使い、`yargs(hideBin(process.argv)).option(...)` として呼び出す

### 2. Deploy Key による master 直接 push (`.github/workflows/generate-readme.yml`)

ruleset 12129661 が master ブランチへの直接 push を禁止しているため、GITHUB_TOKEN による HTTPS push が拒否されていました。

- **修正前**: `https://github-actions:${GITHUB_TOKEN}@github.com/...` で push → ruleset により拒否
- **修正後**: Deploy Key (SSH) を使用し、ruleset の `bypass_actors` にこの Deploy Key を登録することで直接 push を許可

### 3. `workflow_dispatch` での誤 push 防止

`workflow_dispatch` は任意ブランチから手動実行できるため、ハードコードされた `git push origin HEAD:master` が feature ブランチの内容で master を上書きしてしまう危険がありました。`Setup SSH for push` と `Commit & Push` の両ステップに `if: github.ref == 'refs/heads/master'` を追加し、master ブランチ上での実行時のみ push するよう制限しました。

## インフラ変更（このPR外で実施済み）

- Deploy Key をリポジトリに登録（ID: 152342099、書き込み権限）
- 秘密鍵を `PUSH_DEPLOY_KEY` シークレットとして登録
- ruleset 12129661 の `bypass_actors` に `DeployKey` を追加

SSH known_hosts は `ssh-keyscan` を使わず GitHub 公式の固定ホスト鍵を直書きしており、MITM リスクを回避しています（`tomacheese/icons.tomacheese.com` の実績パターンと同一）。

## 関連

- CI 失敗: `TypeError: yargs.option is not a function` (run #26286403345)
- Ruleset: `tomacheese/repo.tomacheese.com` ruleset 12129661 (master ブランチ保護)

🤖 Generated with [Claude Code](https://claude.com/claude-code)