### PR TITLE
fix: SNAPSHOT maven-metadata.xml でのクラッシュを修正

### DIFF
--- a/.github/generate-readme/src/main.ts
+++ b/.github/generate-readme/src/main.ts
@@ -36,35 +36,40 @@ class MavenMetadata {
   }
 }
 
-function parseMavenMetadata(path: string): MavenMetadata {
+function parseMavenMetadata(path: string): MavenMetadata | null {
   const content = fs.readFileSync(path, 'utf8')
   const parser = new XMLParser()
   const metadata: {
     metadata: {
       groupId: string
       artifactId: string
-      versioning: {
+      version?: string
+      versioning?: {
         latest?: string
         release?: string
-        versions: {
-          version: string[]
+        versions?: {
+          version: string | string[]
         }
       }
     }
   } = parser.parse(content)
   console.log(metadata)
   const latestVersion =
-    metadata.metadata.versioning.latest ??
-    metadata.metadata.versioning.release ??
+    metadata.metadata.versioning?.latest ??
+    metadata.metadata.versioning?.release ??
+    metadata.metadata.version ??
     null
   if (latestVersion === null) {
-    throw new Error('latest version not found')
+    console.warn(`latest version not found: ${path} (skipping)`)
+    return null
   }
+  const rawVersions = metadata.metadata.versioning?.versions?.version ?? []
+  const versions = Array.isArray(rawVersions) ? rawVersions : [rawVersions]
   return new MavenMetadata(
     metadata.metadata.groupId,
     metadata.metadata.artifactId,
     latestVersion,
-    metadata.metadata.versioning.versions.version
+    versions
   )
 }
 
@@ -82,15 +87,8 @@ function generateREADME(repositories: MavenMetadata[]) {
   const contents = []
   for (const repository of repositories) {
     const dependencyXml = getDependencyXml(repository)
-    const versions = (
-      Array.isArray(repository.versions)
-        ? repository.versions
-        : [repository.versions]
-    )
-      .map((version) => {
-        console.log(version)
-        return `- \`${version}\``
-      })
+    const versions = repository.versions
+      .map((version) => `- \`${version}\``)
       .join('\n')
 
     contents.push(
@@ -125,9 +123,12 @@ function main() {
     .help()
     .parseSync()
   const mavenMetadataFiles = getMavenMetadataFiles(argv.target)
-  const metadatas = []
+  const metadatas: MavenMetadata[] = []
   for (const mavenMetadataFile of mavenMetadataFiles) {
-    metadatas.push(parseMavenMetadata(mavenMetadataFile))
+    const metadata = parseMavenMetadata(mavenMetadataFile)
+    if (metadata !== null) {
+      metadatas.push(metadata)
+    }
   }
 
   const readme = generateREADME(metadatas)

--- a/.github/generate-readme/src/main.ts
+++ b/.github/generate-readme/src/main.ts
@@ -1,6 +1,7 @@
 import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
-import * as yargs from 'yargs'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 
 function getMavenMetadataFiles(dirpath: string) {
   const files: string[] = []
@@ -110,7 +111,7 @@ ${versions}
 }
 
 function main() {
-  const argv = yargs
+  const argv = yargs(hideBin(process.argv))
     .option('target', {
       description: 'Target path',
       type: 'string',

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -53,6 +53,7 @@ jobs:
       run: pnpm start --target ../../ --output ../../README.md
 
     - name: Setup SSH for push
+      if: github.ref == 'refs/heads/master'
       env:
         PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
       run: |
@@ -90,6 +91,7 @@ jobs:
         git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
 
     - name: Commit & Push
+      if: github.ref == 'refs/heads/master'
       run: |
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -52,12 +52,46 @@ jobs:
       working-directory: ./.github/generate-readme/
       run: pnpm start --target ../../ --output ../../README.md
 
+    - name: Setup SSH for push
+      env:
+        PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+
+        # 秘密鍵を書き込む
+        echo "$PUSH_DEPLOY_KEY" > ~/.ssh/deploy_ed25519
+        chmod 600 ~/.ssh/deploy_ed25519
+
+        # GitHub の公式 SSH ホスト鍵を固定値で書き込む（ssh-keyscan による MITM リスクを回避）
+        cat > ~/.ssh/known_hosts << 'KNOWNHOSTS'
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+        KNOWNHOSTS
+
+        # SSH config を設定
+        cat > ~/.ssh/config << 'SSHCONFIG'
+        Host github.com
+          IdentityFile ~/.ssh/deploy_ed25519
+          StrictHostKeyChecking yes
+          UserKnownHostsFile ~/.ssh/known_hosts
+          BatchMode yes
+        SSHCONFIG
+
+        # SSH 接続テストで Deploy Key 認証を事前確認（exit 1 は GitHub の正常動作）
+        ssh_output=$(ssh -T git@github.com 2>&1 || true)
+        echo "$ssh_output"
+        if [[ "$ssh_output" != *"successfully authenticated"* ]]; then
+          echo "SSH authentication failed"
+          exit 1
+        fi
+
+        # Deploy Key で Ruleset をバイパスするため SSH URL に変更
+        git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+
     - name: Commit & Push
       run: |
-        git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git status | grep modified && git add -A && git commit -v -m "feat: Updated README.md [skip ci]" || true
-        git push origin HEAD:${GITHUB_REF};
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git push origin HEAD:master


### PR DESCRIPTION
## 概要

`dev.kord/kord-bom` など SNAPSHOT 形式の `maven-metadata.xml` を処理するとクラッシュしていた問題を修正します。

## 原因

SNAPSHOT の `maven-metadata.xml` は通常リリースと異なる構造を持ちます：

```xml
<metadata>
  <groupId>dev.kord</groupId>
  <artifactId>kord-bom</artifactId>
  <version>0.15.0-SNAPSHOT</version>  <!-- versioning 内ではなくトップレベル -->
  <versioning>
    <snapshot>...</snapshot>
    <snapshotVersions>...</snapshotVersions>
    <!-- latest / release フィールドなし -->
  </versioning>
</metadata>
```

`parseMavenMetadata` が `versioning.latest` と `versioning.release` しか見ておらず、どちらも存在しない場合に `Error: latest version not found` をスローしていました。

## 修正内容

`parseMavenMetadata` の改善：

1. **バージョン解決のフォールバックチェーン**: `versioning.latest` → `versioning.release` → `metadata.version` (トップレベル) の順で検索
2. **いずれも見つからない場合はスキップ**: エラーをスローせず `null` を返してログ警告を出す
3. **`versioning` / `versions` の optional チェーン化**: SNAPSHOT メタデータは `versioning.versions` も持たないため `?.` を使用
4. **単一バージョン文字列の正規化**: `versions.version` が `string` の場合 (バージョンが 1 つのみ) も配列に変換
5. **`generateREADME` の重複 `Array.isArray` チェックを削除**: `parseMavenMetadata` 内で処理されるため不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)