### PR TITLE
fix: push 前に pull --rebase で non-fast-forward エラーを解消

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -96,4 +96,5 @@ jobs:
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git status | grep modified && git add -A && git commit -v -m "feat: Updated README.md [skip ci]" || true
+        git pull --rebase origin master
         git push origin HEAD:master


### PR DESCRIPTION
## 概要

`generate-readme` ワークフローの `Commit & Push` ステップで non-fast-forward エラーが発生していた問題を修正します。

## 原因

ワークフローが `checkout` した後、`generate README` を実行して `push` するまでの間に、別の commit が master に加わると push が拒否されます。今回は PR #1645・#1646 のマージが checkout 後に行われたため、このエラーが発生しました。

```
! [rejected]        HEAD -> master (fetch first)
error: failed to push some refs to 'github.com:...'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

## 修正内容

`git push` の前に `git pull --rebase origin master` を追加しました。

- README に変更がある場合: ローカルの commit を最新 master の上にリベースしてから push
- README に変更がない場合: pull は no-op、push も差分なしで完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)